### PR TITLE
[zh] FIX: Correct InstanceNorm example input usage

### DIFF
--- a/zh/ch7-regularization-and-normalization/ch7.5-instance-normalization.qmd
+++ b/zh/ch7-regularization-and-normalization/ch7.5-instance-normalization.qmd
@@ -289,7 +289,7 @@ print('running_var shape:', instance_norm.running_var.shape)
 instance_norm.train()
 for _ in range(5):
     x = torch.randn(4, 3, 8, 8)
-    y = instance_norm(torch.randn(4, 3, 8, 8))
+    y = instance_norm(x)
 
 instance_norm.eval()
 x = torch.randn(2, 3, 8, 8)


### PR DESCRIPTION
## Type of Change

- [ ] Adds a new tutorial on a specific topic
- [x] Adds or updates notes, examples, or code comments
- [x] Fixes an error or unclear explanation in the notes
- [ ] Improves wording, structure, formatting, or references
- [ ] Updates `dnnlpy` package code
- [ ] Updates repository tooling, build, or workflow files
- [ ] Other:

## Description

- Fixes the `InstanceNorm2d` example to pass the generated input tensor `x` directly to the normalization layer.

## Checklist

- [x] I've read the [[Contributing Guidelines](https://github.com/jshn9515/deep-learning-notes/blob/main/CONTRIBUTING.md)].

## Related Issue

N/A