### PR TITLE
[zh] MNT: Add simulated hidden state in shape demonstration example

### DIFF
--- a/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
+++ b/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
@@ -110,7 +110,9 @@ embedding = nn.Embedding(vocab_size, embed_dim)
 lm_head = dnn.Linear(embed_dim, vocab_size, bias=False)
 
 x_emb = embedding(input_ids)
-logits = lm_head(x_emb)
+# Only for shape demonstration; the Decoder main body is omitted!
+h_sim = x_emb  
+logits = lm_head(h_sim)
 
 print('Embedding weight shape:', embedding.weight.shape)
 print('LM head weight shape:', lm_head.weight.shape)

--- a/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
+++ b/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
@@ -111,7 +111,7 @@ lm_head = dnn.Linear(embed_dim, vocab_size, bias=False)
 
 x_emb = embedding(input_ids)
 # Only for shape demonstration; the Decoder main body is omitted!
-h_sim = x_emb  
+h_sim = x_emb
 logits = lm_head(h_sim)
 
 print('Embedding weight shape:', embedding.weight.shape)

--- a/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
+++ b/zh/ch18-gpt2-from-scratch/ch18.4-weight-tying.qmd
@@ -111,8 +111,8 @@ lm_head = dnn.Linear(embed_dim, vocab_size, bias=False)
 
 x_emb = embedding(input_ids)
 # Only for shape demonstration; the Decoder main body is omitted!
-h_sim = x_emb
-logits = lm_head(h_sim)
+h = x_emb  # simulated hidden state for shape demonstration
+logits = lm_head(h)
 
 print('Embedding weight shape:', embedding.weight.shape)
 print('LM head weight shape:', lm_head.weight.shape)


### PR DESCRIPTION
## Type of Change

- [ ] Adds a new tutorial on a specific topic
- [x] Adds or updates notes, examples, or code comments
- [ ] Fixes an error or unclear explanation in the notes
- [x] Improves wording, structure, formatting, or references
- [ ] Updates `dnnlpy` package code
- [ ] Updates repository tooling, build, or workflow files
- [ ] Other:

## Description

This change introduces a simulated hidden state `h_sim` with a clarifying comment, making it explicit that the example is only for shape demonstration and the Decoder main body is omitted.

## Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/jshn9515/deep-learning-notes/blob/main/CONTRIBUTING.md).

## Related Issue

N/A